### PR TITLE
Windows: $LIBRARY_PREFIX, autoreconf, shared libraries

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,8 @@ set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
 :: to be Unix-y rather than Windows-y, though.
 set "saved_recipe_dir=%RECIPE_DIR%"
 FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -49,10 +49,9 @@ make check
 
 rm -rf $uprefix/share/man $uprefix/share/doc/libXi
 
-# Prefer dynamic libraries to static, and dump libtool helper files
-for lib_ident in Xi; do
-    #rm -f $uprefix/lib/lib${lib_ident}.la
-    if [ -e $uprefix/lib/lib${lib_ident}$SHLIB_EXT ] ; then
-        rm -f $uprefix/lib/lib${lib_ident}.a
-    fi
-done
+# Non-Windows: prefer dynamic libraries to static, and dump libtool helper files
+if [ -z "VS_MAJOR" ] ; then
+    for lib_ident in Xi; do
+        rm -f $uprefix/lib/lib${lib_ident}.la $uprefix/lib/lib${lib_ident}.a
+    done
+fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,14 +6,37 @@ IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
 # Adopt a Unix-friendly path if we're on Windows (see bld.bat).
 [ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
 
-# Fresh OS-guessing scripts from xorg-util-macros for win64
-for f in config.guess config.sub ; do
-    cp -p $PREFIX/share/util-macros/$f .
-done
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
 
-export PKG_CONFIG_LIBDIR=$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
 configure_args=(
-    --prefix=$PREFIX
+    --prefix=$mprefix
     --disable-dependency-tracking
     --disable-selective-werror
     --disable-silent-rules
@@ -24,12 +47,12 @@ make -j$CPU_COUNT
 make install
 make check
 
-rm -rf $PREFIX/share/man $PREFIX/share/doc/libXi
+rm -rf $uprefix/share/man $uprefix/share/doc/libXi
 
 # Prefer dynamic libraries to static, and dump libtool helper files
 for lib_ident in Xi; do
-    rm -f $PREFIX/lib/lib${lib_ident}.la
-    if [ -e $PREFIX/lib/lib${lib_ident}$SHLIB_EXT ] ; then
-        rm -f $PREFIX/lib/lib${lib_ident}.a
+    #rm -f $uprefix/lib/lib${lib_ident}.la
+    if [ -e $uprefix/lib/lib${lib_ident}$SHLIB_EXT ] ; then
+        rm -f $uprefix/lib/lib${lib_ident}.a
     fi
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,6 +3,7 @@
 {% set name = "xorg-" ~ xorg_name %}
 {% set version = "1.7.8" %}
 {% set sha256 = "d8f2fa8d53141c41ff521627df9b2fa9c05f6f142fd9881152bab36549ac27bb" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
 
 package:
   name: {{ name|lower }}
@@ -14,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   features:
     - vc9  # [win and py27]
@@ -23,6 +24,9 @@ build:
 
 requirements:
   build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
     - m2w64-pkg-config  # [win]
     - m2w64-toolchain  # [win]
     - pkg-config  # [not win]


### PR DESCRIPTION
The first attempt to build this on Windows might fail if the dependent libraries haven't yet been updated, but we can at least get the CircleCI and Travis builds taken care of.